### PR TITLE
Fix: Correct broken navigation links in question_bank.html

### DIFF
--- a/app/templates/teacher/question_bank.html
+++ b/app/templates/teacher/question_bank.html
@@ -13,10 +13,10 @@
         </div>
         <nav class="dashboard-nav">
             <ul>
-                <li><a href="#">Dashboard</a></li>
-                <li class="active"><a href="#">Question Bank</a></li>
+                <li><a href="{{ url_for('main.teacher_dashboard') }}">Dashboard</a></li>
+                <li class="active"><a href="{{ url_for('main.question_bank') }}">Question Bank</a></li>
                 <li><a href="{{ url_for('main.teacher_exams') }}">Exams</a></li>
-                <li><a href="{{ url_for('main.results') }}">Results</a></li>
+                <li><a href="{{ url_for('main.grading_list') }}">Grading</a></li>
                 <li><a href="{{ url_for('main.settings') }}">Settings</a></li>
             </ul>
         </nav>


### PR DESCRIPTION
This commit fixes the sidebar navigation links in the `app/templates/teacher/question_bank.html` template. The "Dashboard" and "Question Bank" links were previously unlinked, and the "Results" link was pointing to a non-existent route.

The following changes have been made:
- The "Dashboard" link now correctly points to `main.teacher_dashboard`.
- The "Question Bank" link now correctly points to `main.question_bank`.
- The "Results" link has been updated to "Grading" for consistency and now correctly points to `main.grading_list`.