### PR TITLE
Fix: Refactor role_required decorator to accept multiple roles

### DIFF
--- a/app/decorators.py
+++ b/app/decorators.py
@@ -2,19 +2,19 @@ from functools import wraps
 from flask import abort
 from flask_login import current_user
 
-def role_required(role):
+def role_required(*roles):
     """
-    Decorator that restricts access to a route to users with a specific role.
+    Decorator that restricts access to a route to users with specific roles.
     """
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
             if not current_user.is_authenticated:
                 # This should be handled by login_required, but as a safeguard
-                return abort(401)
-            if current_user.role.value != role:
-                # If the user does not have the required role
-                return abort(403)
+                abort(401)
+            if current_user.role.value not in roles:
+                # If the user does not have any of the required roles
+                abort(403)
             return f(*args, **kwargs)
         return decorated_function
     return decorator


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred when the `@role_required` decorator was used with multiple arguments. The decorator was previously designed to accept only a single role, causing a crash when used on routes accessible to more than one user role (e.g., teachers and admins).

The `role_required` function in `app/decorators.py` has been refactored to accept a variable number of role arguments (`*roles`). It now correctly checks if the `current_user.role.value` is present in the list of provided roles, ensuring that the decorator works as intended for routes with multiple authorized roles.